### PR TITLE
Python 3.11!

### DIFF
--- a/.github/workflows/pythonapp.yml
+++ b/.github/workflows/pythonapp.yml
@@ -9,10 +9,10 @@ jobs:
 
     steps:
     - uses: actions/checkout@v1
-    - name: Set up Python 3.7
+    - name: Set up Python 3.11
       uses: actions/setup-python@v1
       with:
-        python-version: 3.7
+        python-version: 3.11
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,0 +1,16 @@
+# https://docs.readthedocs.io/en/stable/config-file/v2.html
+
+version: 2
+
+build:
+  os: "ubuntu-22.04"
+  tools:
+    python: "3.11"
+
+sphinx:
+  builder: "dirhtml"
+  configuration: "source/conf.py"
+
+python:
+  install:
+    - requirements: "requirements.txt"


### PR DESCRIPTION
Python 3.7 is now receiving security fixes only, and latest Sphinx (6) dropped support for it. 3.11 is the latest stable, and supported by ReadTheDocs https://docs.readthedocs.io/en/stable/config-file/v2.html#python