### PR TITLE
Include decision date in document title for better viewing

### DIFF
--- a/source/decisions/2019-11-30-pylondinium.rst
+++ b/source/decisions/2019-11-30-pylondinium.rst
@@ -1,5 +1,5 @@
-Response to PyLondinium Support Request
-=======================================
+2019-11-30 Response to PyLondinium Support Request
+==================================================
 
 This decision was taken at :doc:`../meetings/trustees/2019-11-30` according to section
 17.1 of the UKPA Constitution.

--- a/source/decisions/2019-11-30-ukpatl-deeds.rst
+++ b/source/decisions/2019-11-30-ukpatl-deeds.rst
@@ -1,5 +1,5 @@
-Resolution to Sign UKPA Trading Ltd Deeds
-=========================================
+2019-11-30 Resolution to Sign UKPA Trading Ltd Deeds
+====================================================
 
 Background
 ----------

--- a/source/decisions/2020-01-10-pyconna2020.rst
+++ b/source/decisions/2020-01-10-pyconna2020.rst
@@ -1,5 +1,5 @@
-Response to PyCon Namibia Sponsorship Request
-=============================================
+2020-01-10 Response to PyCon Namibia Sponsorship Request
+========================================================
 
 This decision was taken at :doc:`../meetings/trustees/2020-01-10` according to section
 17.1 of the UKPA Constitution.

--- a/source/decisions/2020-02-15-add-policy-on-minors.rst
+++ b/source/decisions/2020-02-15-add-policy-on-minors.rst
@@ -1,5 +1,5 @@
-Policy on minors
-================
+2020-02-15 Policy on minors
+===========================
 
 This decision was taken at :doc:`../meetings/trustees/2020-02-15` according to
 section 17.1 of the UKPA Constitution.

--- a/source/decisions/2020-02-15-create-designated-fund-for-financial-aid.rst
+++ b/source/decisions/2020-02-15-create-designated-fund-for-financial-aid.rst
@@ -1,5 +1,5 @@
-Create designated fund for financial assistance
-===============================================
+2020-02-15 Create designated fund for financial assistance
+==========================================================
 
 This decision was taken at :doc:`../meetings/trustees/2020-02-15` according to
 section 17.1 of the UKPA Constitution.

--- a/source/decisions/2020-02-15-john-pinner-award-chair.rst
+++ b/source/decisions/2020-02-15-john-pinner-award-chair.rst
@@ -1,5 +1,5 @@
-Appoint John Pinner Award Chair
-===============================
+2020-02-15 Appoint John Pinner Award Chair
+==========================================
 
 This decision was taken at :doc:`../meetings/trustees/2020-02-15` according to
 section 17.1 of the UKPA Constitution.

--- a/source/decisions/2020-02-15-lawyers-and-accountants.rst
+++ b/source/decisions/2020-02-15-lawyers-and-accountants.rst
@@ -1,5 +1,5 @@
-Lawyers and accountants
-=======================
+2020-02-15 Lawyers and accountants
+==================================
 
 This decision was taken at :doc:`../meetings/trustees/2020-02-15` according to
 section 17.1 of the UKPA Constitution.

--- a/source/decisions/2020-02-15-modify-john-pinner-award-policy.rst
+++ b/source/decisions/2020-02-15-modify-john-pinner-award-policy.rst
@@ -1,5 +1,5 @@
-Modify John Pinner Award Policy
-===============================
+2020-02-15 Modify John Pinner Award Policy
+==========================================
 
 This decision was taken at :doc:`../meetings/trustees/2020-02-15` according to
 section 17.1 of the UKPA Constitution.

--- a/source/decisions/2020-02-15-open-new-bank-account.rst
+++ b/source/decisions/2020-02-15-open-new-bank-account.rst
@@ -1,5 +1,5 @@
-Open new bank account
-=====================
+2020-02-15 Open new bank account
+================================
 
 This decision was taken at :doc:`../meetings/trustees/2020-02-15` according to
 section 17.1 of the UKPA Constitution.

--- a/source/decisions/2020-04-27-conference-director-appointment.rst
+++ b/source/decisions/2020-04-27-conference-director-appointment.rst
@@ -1,5 +1,5 @@
-Resolution to Appoint the Conference Director
-=============================================
+2020-04-27 Resolution to Appoint the Conference Director
+========================================================
 
 Resolution
 ----------

--- a/source/decisions/2020-11-13-membership-extension.rst
+++ b/source/decisions/2020-11-13-membership-extension.rst
@@ -1,5 +1,5 @@
-Resolution to Extend 2019 Membership
-====================================
+2020-11-13 Resolution to Extend 2019 Membership
+===============================================
 
 Resolution
 ----------

--- a/source/decisions/2022-11-19-appoint-becky-smith-as-trustee.rst
+++ b/source/decisions/2022-11-19-appoint-becky-smith-as-trustee.rst
@@ -1,5 +1,5 @@
-Appoint Becky Smith as Trustee
-==============================
+2022-11-19 Appoint Becky Smith as Trustee
+=========================================
 
 Resolution
 ----------

--- a/source/decisions/2022-11-19-decide-on-pyconuk-accommodation-policy-for-conference.rst
+++ b/source/decisions/2022-11-19-decide-on-pyconuk-accommodation-policy-for-conference.rst
@@ -1,5 +1,5 @@
-Decision on accommodation policy for conference
-===============================================
+2022-11-19 Decision on accommodation policy for conference
+==========================================================
 
 Resolution
 ----------

--- a/source/decisions/2022-11-19-djangocon-europe-2023.rst
+++ b/source/decisions/2022-11-19-djangocon-europe-2023.rst
@@ -1,5 +1,5 @@
-Response to DjangoCon Europe Request for Support
-================================================
+2022-11-29 Response to DjangoCon Europe Request for Support
+===========================================================
 
 
 Request

--- a/source/decisions/2022-11-19-treasurer-and-chair.rst
+++ b/source/decisions/2022-11-19-treasurer-and-chair.rst
@@ -1,5 +1,5 @@
-Name chair and treasurer of UKPA
-================================
+2022-11-19 Name chair and treasurer of UKPA
+===========================================
 
 Resolution
 ----------

--- a/source/decisions/2022-11-19-update-meetings-notice.rst
+++ b/source/decisions/2022-11-19-update-meetings-notice.rst
@@ -1,5 +1,5 @@
-Update to calling of meetings policy
-====================================
+2022-11-19 Update to calling of meetings policy
+===============================================
 
 Resolution
 ----------

--- a/source/decisions/2023-03-04-adopt-policy-on-minors.rst
+++ b/source/decisions/2023-03-04-adopt-policy-on-minors.rst
@@ -1,5 +1,5 @@
-Policy on minors
-================
+2023-03-04 Policy on minors
+===========================
 
 Decision
 --------

--- a/source/decisions/2023-03-04-approval-of-conference-director-recommendation-for-accomodation.rst
+++ b/source/decisions/2023-03-04-approval-of-conference-director-recommendation-for-accomodation.rst
@@ -1,5 +1,5 @@
-Approval of PyCon UK director recommendation for conference accommodation
-=========================================================================
+2023-03-04 Approval of PyCon UK director recommendation for conference accommodation
+====================================================================================
 
 Resolution
 ----------

--- a/source/decisions/2023-03-04-invocation-of-clause-15.1.2.rst
+++ b/source/decisions/2023-03-04-invocation-of-clause-15.1.2.rst
@@ -1,5 +1,5 @@
-Vacation of office of a trustee
-===============================
+2023-03-04 Vacation of office of a trustee
+==========================================
 
 Resolution
 ----------


### PR DESCRIPTION
Right now, we record the decision date in the Git history itself (implicitly) and the filename of the decision (explicitly), but not actually in the *content* of the decision itself

This means that e.g.
https://ukpa-internaldocs.readthedocs.io/en/latest/decisions/ presents you a list of decisions but without actual explicit context of when these were (to be able to check e.g. what's new), and the only real way to see on the published site is to look at the URL path itself, e.g. https://ukpa-internaldocs.readthedocs.io/en/latest/decisions/2019-11-30-ukpatl-deeds/

This commit makes the dates an explicit part of the decision title, which should both increase clarity overall, and also reduce confusion if we ever assign the same title to a decision that was used previously (e.g. if we make a subsequent decision pertaining to "UKPATL Deeds")