### PR TITLE
Fix ReadTheDocs build to support Pipenv

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -6,6 +6,10 @@ build:
   os: "ubuntu-22.04"
   tools:
     python: "3.11"
+  jobs:
+    pre_install:
+      - "pip install pipenv"
+      - "pipenv requirements > requirements.txt"
 
 sphinx:
   builder: "dirhtml"


### PR DESCRIPTION
I accidentally broke the RTD build with
253b4b68b248450390619872c3b1d0bf36f93c12 when moving from
requirements.txt to Pipenv

This was not helped by not having automated tests for RTD builds - I
have subsequently enabled RTD Pull Request Previews
(https://docs.readthedocs.io/en/stable/pull-requests.html) to find out
in advance if anything is broken(!)

In terms of the core issue, RTD have decided to not support Pipenv
(https://github.com/readthedocs/readthedocs.org/pull/8851 etc.) so
instead we shim things:

Rather than adopt a full-on "make RTD use Pipenv for dependencies", this
just has Pipenv generate a requirements.txt for RTD to use as it did
previously
